### PR TITLE
LuaStateFactory: fix removeLuaState

### DIFF
--- a/src/java/org/keplerproject/luajava/LuaStateFactory.java
+++ b/src/java/org/keplerproject/luajava/LuaStateFactory.java
@@ -106,7 +106,7 @@ public final class LuaStateFactory
 	 */
 	public synchronized static void removeLuaState(int idx)
 	{
-		states.add(idx, null);
+		states.set(idx, null);
 	}
 	
 	/**


### PR DESCRIPTION
Using List.set instead of List.add.

This way, overwrites the state instead of inserting a null state and causing issues with state indices being off by one after calling LuaState.close().
